### PR TITLE
refactor: クリーンアーキテクチャに基づくレイヤー分離

### DIFF
--- a/internal/domain/event.go
+++ b/internal/domain/event.go
@@ -1,0 +1,14 @@
+package domain
+
+import "time"
+
+// Event カレンダーイベントのドメインエンティティ
+type Event struct {
+	ID          string
+	Title       string
+	StartTime   time.Time
+	EndTime     time.Time
+	IsAllDay    bool
+	Location    string
+	Description string
+}

--- a/internal/usecase/notify_schedule.go
+++ b/internal/usecase/notify_schedule.go
@@ -1,0 +1,63 @@
+package usecase
+
+import (
+	"context"
+	"log"
+	"time"
+
+	"github.com/k-negishi/google-calendar-line-notifier/internal/domain"
+)
+
+// CalendarRepository カレンダーからイベントを取得するポート
+type CalendarRepository interface {
+	GetEvents(ctx context.Context, targetDate time.Time) ([]domain.Event, error)
+}
+
+// Notifier 通知を送信するポート
+type Notifier interface {
+	SendScheduleNotification(ctx context.Context, todayEvents, tomorrowEvents []domain.Event) error
+}
+
+// NotifyScheduleUseCase 予定通知ユースケース
+type NotifyScheduleUseCase struct {
+	calendarRepo CalendarRepository
+	notifier     Notifier
+}
+
+// NewNotifyScheduleUseCase ユースケースを生成
+func NewNotifyScheduleUseCase(calendarRepo CalendarRepository, notifier Notifier) *NotifyScheduleUseCase {
+	return &NotifyScheduleUseCase{
+		calendarRepo: calendarRepo,
+		notifier:     notifier,
+	}
+}
+
+// Execute 今日と明日の予定を取得し、LINE通知を送信する
+func (uc *NotifyScheduleUseCase) Execute(ctx context.Context, today, tomorrow time.Time) (skipped bool, err error) {
+	// 今日の予定を取得
+	todayEvents, err := uc.calendarRepo.GetEvents(ctx, today)
+	if err != nil {
+		log.Printf("今日の予定取得に失敗しました: %v", err)
+		return false, err
+	}
+
+	// 明日の予定を取得
+	tomorrowEvents, err := uc.calendarRepo.GetEvents(ctx, tomorrow)
+	if err != nil {
+		log.Printf("明日の予定取得に失敗しました: %v", err)
+		return false, err
+	}
+
+	// 予定が両日ともない場合はスキップ
+	if len(todayEvents) == 0 && len(tomorrowEvents) == 0 {
+		return true, nil
+	}
+
+	// LINE通知を送信
+	if err := uc.notifier.SendScheduleNotification(ctx, todayEvents, tomorrowEvents); err != nil {
+		log.Printf("LINE通知の送信に失敗しました: %v", err)
+		return false, err
+	}
+
+	return false, nil
+}


### PR DESCRIPTION
- domain層: 共通のEventエンティティを定義し、重複するEvent構造体を統合
- usecase層: CalendarRepository/Notifierポートインターフェースと
  NotifyScheduleUseCaseを導入し、ビジネスロジックをhandlerから分離
- gateway層: Google Calendar APIとLINE Messaging APIの具象実装を
  アダプタとして配置し、依存性逆転の原則に準拠
- cmd/main.go: DI（依存性注入）のみを行う薄いハンドラーに簡素化
- 旧パッケージ（internal/calendar, internal/linenotifier）を削除

https://claude.ai/code/session_01FfQSfMYGar3AUFiWxyrapS